### PR TITLE
Red Hat Enterprise Linux Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.retry
+.molecule/*
+.vagrant/*

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,22 @@
       file:
         path: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
         state: absent
+    
+    - name: Change packer mode to 655
+      file:
+        path: "{{ packer_install_directory }}"
+        mode: 0655
+        recurse: yes      
   when: check_existing_packer.stat.exists == False
+
+- name: Symlink packer to correct version on RHEL/CentOS
+  file:
+    path: "{{ packer_install_directory }}/packer.io"
+    src: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer"
+    state: link
+    force: yes
+    mode: 0655
+  when: ansible_os_family == "RedHat"
 
 - name: Symlink packer to correct version
   file:
@@ -43,3 +58,4 @@
     mode: 0645
     owner: root
     group: root
+  when: ansible_os_family != "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,42 +3,35 @@
   stat:
     path: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer"
   register: check_existing_packer
-  become: yes
 
 - block:
     - name: Create packer version directory
       file:
         name: "{{ packer_install_directory }}/packer_{{ packer_version }}"
         state: directory
-      become: yes
 
     - name: Download packer archive
       get_url:
         url: "https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
         dest: "{{ packer_install_directory }}/packer_{{ packer_version }}/"
       register: download_packer_archive
-      become: yes
 
     - name: Install unzip
       package:
         name: unzip
-      become: yes
-      when: download_packer_archive.changed == True
+      when: download_packer_archive|changed
 
     - name: Unarchive packer
       unarchive:
         src: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
         dest: "{{ packer_install_directory }}/packer_{{ packer_version }}/"
         remote_src: yes
-      become: yes
-      when: download_packer_archive.changed == True
+      when: download_packer_archive|changed
 
     - name: Remove packer archive
       file:
         path: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
         state: absent
-      become: yes
-
   when: check_existing_packer.stat.exists == False
 
 - name: Symlink packer to correct version
@@ -50,4 +43,3 @@
     mode: 0777
     owner: root
     group: root
-  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,10 @@
     path: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer"
   register: check_existing_packer
 
+- name: Install unzip
+  package:
+    name: unzip
+
 - block:
     - name: Create packer version directory
       file:
@@ -14,30 +18,23 @@
       get_url:
         url: "https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
         dest: "{{ packer_install_directory }}/packer_{{ packer_version }}/"
-      register: download_packer_archive
-
-    - name: Install unzip
-      package:
-        name: unzip
-      when: download_packer_archive|changed
 
     - name: Unarchive packer
       unarchive:
         src: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
         dest: "{{ packer_install_directory }}/packer_{{ packer_version }}/"
         remote_src: yes
-      when: download_packer_archive|changed
 
     - name: Remove packer archive
       file:
         path: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
         state: absent
-    
+
     - name: Change packer mode to 655
       file:
         path: "{{ packer_install_directory }}"
         mode: 0655
-        recurse: yes      
+        recurse: yes
   when: check_existing_packer.stat.exists == False
 
 - name: Symlink packer to correct version on RHEL/CentOS

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,6 @@
     src: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer"
     state: link
     force: yes
-    mode: 0777
+    mode: 0645
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,5 @@
     src: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer"
     state: link
     force: yes
-    mode: 0645
-    owner: root
-    group: root
+    mode: 0655
   when: ansible_os_family != "RedHat"


### PR DESCRIPTION
The Red Hat family already has a "packer" package. So we need to change
the packer name to packer.io

As extra stuffs, i've done:
* some syntax changes
* remove conditions that wasn't really necessary
* change packer permission from 777 for 645 (security reasons)
* add vagrant and molecule folders to gitignore